### PR TITLE
Use PHP 5.5 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,10 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm
   - nightly
-
-matrix:
-  allow_failures:
-    - php: nightly
 
 before_script:
   - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.5.0/setup' -O - | php

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
   "description" : "Logging for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^6.4.2",
-    "php" : ">=5.4.0"
+    "xp-framework/core": "^6.5.0",
+    "php" : ">=5.5.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/test/php/util/log/unittest/ConsoleAppenderTest.class.php
+++ b/src/test/php/util/log/unittest/ConsoleAppenderTest.class.php
@@ -24,7 +24,7 @@ class ConsoleAppenderTest extends TestCase {
    */
   public function setUp() {
     $this->cat= (new LogCategory('default'))->withAppender(
-      (new ConsoleAppender())->withLayout(newinstance('util.log.Layout', [], [
+      (new ConsoleAppender())->withLayout(newinstance(Layout::class, [], [
         'format' => function(LoggingEvent $event) {
           return implode(' ', $event->getArguments());
         }

--- a/src/test/php/util/log/unittest/FileAppenderTest.class.php
+++ b/src/test/php/util/log/unittest/FileAppenderTest.class.php
@@ -166,7 +166,7 @@ class FileAppenderTest extends AppenderTest {
 
   #[@test]
   public function filename_syncs_with_time() {
-    $fixture= newinstance('util.log.FileAppender', ['test://fn%H'], '{
+    $fixture= newinstance(FileAppender::class, ['test://fn%H'], '{
       protected $hour= 0;
       public function filename($ref= null) {
         return parent::filename(0 + 3600 * $this->hour++);

--- a/src/test/php/util/log/unittest/LogAppenderTest.class.php
+++ b/src/test/php/util/log/unittest/LogAppenderTest.class.php
@@ -15,7 +15,7 @@ class LogAppenderTest extends TestCase {
    */
   public function setUp() {
     $this->events= create('new util.collections.Vector<string>()');
-    $appender= newinstance('util.log.Appender', [$this->events], [
+    $appender= newinstance(Appender::class, [$this->events], [
       'events' => null,
       '__construct' => function($events) { $this->events= $events; },
       'append' => function(LoggingEvent $event) {

--- a/src/test/php/util/log/unittest/LogCategoryTest.class.php
+++ b/src/test/php/util/log/unittest/LogCategoryTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\log\unittest;
  
+use util\log\layout\DefaultLayout;
 use util\log\LogCategory;
 use util\log\Logger;
 use util\log\Appender;
@@ -18,7 +19,7 @@ class LogCategoryTest extends \unittest\TestCase {
    * @return  util.log.Appender
    */
   private function mockAppender() {
-    $appender= newinstance('util.log.Appender', [], [
+    $appender= newinstance(Appender::class, [], [
       'messages' => [],
       'append' => function(LoggingEvent $event) {
         $this->messages[]= [
@@ -36,7 +37,7 @@ class LogCategoryTest extends \unittest\TestCase {
    * @return  util.log.Appender
    */
   private function emptyAppender() {
-    return newinstance('util.log.Appender', [], [
+    return newinstance(Appender::class, [], [
       'append' => function(LoggingEvent $event) { }
     ]);
   }
@@ -72,7 +73,7 @@ class LogCategoryTest extends \unittest\TestCase {
 
   #[@test]
   public function can_create_with_identifier_level_and_context() {
-    new LogCategory('identifier', LogLevel::ALL, newinstance('util.log.Context', [], [
+    new LogCategory('identifier', LogLevel::ALL, newinstance(Context::class, [], [
       'format' => function() { return ''; }
     ]));
   }
@@ -145,7 +146,7 @@ class LogCategoryTest extends \unittest\TestCase {
     $cat= new LogCategory();
     $appender= $this->emptyAppender();
     $cat->addAppender($appender);
-    $this->assertInstanceOf('util.log.layout.DefaultLayout', $appender->getLayout());
+    $this->assertInstanceOf(DefaultLayout::class, $appender->getLayout());
   }
 
   #[@test]
@@ -153,7 +154,7 @@ class LogCategoryTest extends \unittest\TestCase {
     $cat= new LogCategory();
     $appender= $this->emptyAppender();
     $cat->addAppender($appender->withLayout(new PatternLayout('%m')));
-    $this->assertInstanceOf('util.log.layout.PatternLayout', $appender->getLayout());
+    $this->assertInstanceOf(PatternLayout::class, $appender->getLayout());
   }
 
   #[@test]
@@ -161,7 +162,7 @@ class LogCategoryTest extends \unittest\TestCase {
     $cat= new LogCategory();
     $appender= $this->emptyAppender();
     $cat->withAppender($appender);
-    $this->assertInstanceOf('util.log.layout.DefaultLayout', $appender->getLayout());
+    $this->assertInstanceOf(DefaultLayout::class, $appender->getLayout());
   }
 
   #[@test]
@@ -169,7 +170,7 @@ class LogCategoryTest extends \unittest\TestCase {
     $cat= new LogCategory();
     $appender= $this->emptyAppender();
     $cat->withAppender($appender->withLayout(new PatternLayout('%m')));
-    $this->assertInstanceOf('util.log.layout.PatternLayout', $appender->getLayout());
+    $this->assertInstanceOf(PatternLayout::class, $appender->getLayout());
   }
 
   #[@test]

--- a/src/test/php/util/log/unittest/LoggerTest.class.php
+++ b/src/test/php/util/log/unittest/LoggerTest.class.php
@@ -1,5 +1,10 @@
 <?php namespace util\log\unittest;
  
+use util\log\LogCategory;
+use util\Configurable;
+use util\log\FileAppender;
+use util\log\SmtpAppender;
+use util\log\context\NestedLogContext;
 use util\log\Logger;
 
 /**
@@ -31,14 +36,14 @@ class LoggerTest extends \unittest\TestCase {
   #[@test]
   public function defaultCategory() {
     with ($cat= $this->logger->getCategory()); {
-      $this->assertInstanceOf('util.log.LogCategory', $cat);
+      $this->assertInstanceOf(LogCategory::class, $cat);
       $this->assertFalse($cat->hasAppenders());
     }
   }
 
   #[@test]
   public function isConfigurable() {
-    $this->assertInstanceOf('util.Configurable', $this->logger);
+    $this->assertInstanceOf(Configurable::class, $this->logger);
   }
 
   #[@test]
@@ -57,13 +62,13 @@ appender.util.log.FileAppender.param.filename="/var/log/xp/remote.log"
     
     with ($sql= $this->logger->getCategory('sql')); {
       $appenders= $sql->getAppenders();
-      $this->assertInstanceOf('util.log.FileAppender', $appenders[0]);
+      $this->assertInstanceOf(FileAppender::class, $appenders[0]);
       $this->assertEquals('/var/log/xp/sql.log', $appenders[0]->filename);
     }
     
     with ($sql= $this->logger->getCategory('remote')); {
       $appenders= $sql->getAppenders();
-      $this->assertInstanceOf('util.log.FileAppender', $appenders[0]);
+      $this->assertInstanceOf(FileAppender::class, $appenders[0]);
       $this->assertEquals('/var/log/xp/remote.log', $appenders[0]->filename);
     }
   }
@@ -81,9 +86,9 @@ appender.util.log.SmtpAppender.param.email="xp@example.com"
     
     with ($sql= $this->logger->getCategory('sql')); {
       $appenders= $sql->getAppenders();
-      $this->assertInstanceOf('util.log.FileAppender', $appenders[0]);
+      $this->assertInstanceOf(FileAppender::class, $appenders[0]);
       $this->assertEquals('/var/log/xp/sql.log', $appenders[0]->filename);
-      $this->assertInstanceOf('util.log.SmtpAppender', $appenders[1]);
+      $this->assertInstanceOf(SmtpAppender::class, $appenders[1]);
       $this->assertEquals('xp@example.com', $appenders[1]->email);
     }
   }
@@ -100,10 +105,10 @@ appender.util.log.FileAppender.flags="LOGGER_FLAG_ERROR|LOGGER_FLAG_WARN"
     
     with ($cat= $this->logger->getCategory('sql')); {
       $this->assertFalse($cat === $this->logger->getCategory());
-      $this->assertInstanceOf('util.log.LogCategory', $cat);
+      $this->assertInstanceOf(LogCategory::class, $cat);
       $this->assertTrue($cat->hasAppenders());
       with ($appenders= $cat->getAppenders(\util\log\LogLevel::ERROR | \util\log\LogLevel::WARN)); {
-        $this->assertInstanceOf('util.log.FileAppender', $appenders[0]);
+        $this->assertInstanceOf(FileAppender::class, $appenders[0]);
       }
     }
   }
@@ -120,10 +125,10 @@ appender.util.log.FileAppender.levels="ERROR|WARN"
     
     with ($cat= $this->logger->getCategory('sql')); {
       $this->assertFalse($cat === $this->logger->getCategory());
-      $this->assertInstanceOf('util.log.LogCategory', $cat);
+      $this->assertInstanceOf(LogCategory::class, $cat);
       $this->assertTrue($cat->hasAppenders());
       with ($appenders= $cat->getAppenders(\util\log\LogLevel::ERROR | \util\log\LogLevel::WARN)); {
-        $this->assertInstanceOf('util.log.FileAppender', $appenders[0]);
+        $this->assertInstanceOf(FileAppender::class, $appenders[0]);
       }
     }
   }
@@ -140,7 +145,7 @@ appender.util.log.FileAppender.param.filename="/var/log/xp/default.log"
 
     with ($cat= $this->logger->getCategory('context')); {
       $this->assertTrue($cat->hasContext());
-      $this->assertInstanceOf('util.log.context.NestedLogContext', $cat->getContext());
+      $this->assertInstanceOf(NestedLogContext::class, $cat->getContext());
     }
   }
 

--- a/src/test/php/util/log/unittest/SmtpAppenderTest.class.php
+++ b/src/test/php/util/log/unittest/SmtpAppenderTest.class.php
@@ -14,7 +14,7 @@ class SmtpAppenderTest extends AppenderTest {
    * @return  util.log.SmtpAppender
    */
   protected function newFixture($prefix, $sync) {
-    $appender= newinstance('util.log.SmtpAppender', ['test@example.com', $prefix, $sync], '{
+    $appender= newinstance(SmtpAppender::class, ['test@example.com', $prefix, $sync], '{
       public $sent= [];
       protected function send($prefix, $content) {
         $this->sent[]= [$prefix, $content];


### PR DESCRIPTION
This pull request drops PHP 5.4 support by starting to rely on `T::class` and bumps the minimum PHP version required to 5.5. Converted using [this unperfect script](https://gist.github.com/thekid/d87c0db1f5902af26c4f) using PHP 5.5 mode

_Note: As the main source is not touched, unofficial PHP 5.4 support is still available though not tested with Travis-CI. This is consistent with [xp core 6.5.0](https://github.com/xp-framework/core/releases/tag/v6.5.0)._
