### PR TITLE
Make hostname configurable via constructor / Logger::configure()

### DIFF
--- a/src/main/php/util/log/SyslogUdpAppender.class.php
+++ b/src/main/php/util/log/SyslogUdpAppender.class.php
@@ -23,6 +23,9 @@ class SyslogUdpAppender extends Appender {
   /** @var int */
   public $port;
 
+  /** @var string */
+  public $hostname;
+
   /**
    * SyslogUdpAppender constructor.
    *
@@ -30,12 +33,14 @@ class SyslogUdpAppender extends Appender {
    * @param int $port default 514
    * @param ?string $identifier - if omitted, uses PHP_SELF
    * @param int $facility default LOG_USER
+   * @param ?string $hostname defaults to gethostname()
    */
-  public function __construct($ip= '127.0.0.1', $port= 514, $identifier= null, $facility= LOG_USER) {
+  public function __construct($ip= '127.0.0.1', $port= 514, $identifier= null, $facility= LOG_USER, $hostname= null) {
     $this->ip= $ip;
     $this->port= $port;
     $this->identifier= $identifier ?: basename($_SERVER['PHP_SELF']);
     $this->facility= $facility;
+    $this->hostname= $hostname ?: gethostname() ?: '-';
   }
 
   /**
@@ -69,7 +74,7 @@ class SyslogUdpAppender extends Appender {
       '<%d>1 %s %s %s %s - - ',
       $priority,
       $this->currentDate(),
-      (gethostname() ?: '-'),
+      $this->hostname,
       $this->identifier,
       (getmypid() ?: '-')
     );

--- a/src/test/php/util/log/unittest/SyslogUdpAppenderTest.class.php
+++ b/src/test/php/util/log/unittest/SyslogUdpAppenderTest.class.php
@@ -39,6 +39,24 @@ class SyslogUdpAppenderTest extends TestCase {
     $this->assertEquals(basename($_SERVER['PHP_SELF']), $fixture->identifier);
   }
 
+  #[@test]
+  public function identifier_can_be_set() {
+    $fixture= new SyslogUdpAppender('127.0.0.1', 514, 'test-identifier', LOG_USER);
+    $this->assertEquals('test-identifier', $fixture->identifier);
+  }
+
+  #[@test]
+  public function hostname_defaults_to_gethostname() {
+    $fixture= new SyslogUdpAppender('127.0.0.1', 514, null, LOG_USER);
+    $this->assertEquals(gethostname(), $fixture->hostname);
+  }
+
+  #[@test]
+  public function hostname_can_be_set() {
+    $fixture= new SyslogUdpAppender('127.0.0.1', 514, null, LOG_USER, 'test-host');
+    $this->assertEquals('test-host', $fixture->hostname);
+  }
+
   #[@test, @values('levels')]
   public function formatting($level, $priority) {
     $message= 'BOM\'su root\' failed for lonvick on /dev/pts/8';


### PR DESCRIPTION
For use in Docker containers, which have senseless hostnames. Users may want to pass in another identifier, such as the cluster name

/cc @johannes85