### PR TITLE
Change ConsoleAppender to log to standard output by default

### DIFF
--- a/src/main/php/util/log/ColoredConsoleAppender.class.php
+++ b/src/main/php/util/log/ColoredConsoleAppender.class.php
@@ -11,31 +11,28 @@
  * @see  xp://util.log.ConsoleAppender
  */  
 class ColoredConsoleAppender extends ConsoleAppender {
+  private static $DEFAULTS;
   protected $colors= [];
+
+  static function __static() {
+    self::$DEFAULTS= [
+      LogLevel::INFO  => '00;00',
+      LogLevel::WARN  => '00;31',
+      LogLevel::ERROR => '01;31',
+      LogLevel::DEBUG => '00;34'
+    ];
+  }
 
   /**
    * Constructor
    *
-   * @param   string cerror default '01;31' color for errors
-   * @param   string cwarn default '00;31' color for warnings
-   * @param   string cinfo default '00;00' color for information
-   * @param   string cdebug default '00;34' color for debug
-   * @param   string cdefault default '07;37' default color
+   * @param  string|io.streams.StringWriter $target
+   * @param  [:string] $colors
+   * @throws lang.IllegalArgumentException
    */
-  public function __construct(
-    $cerror   = '01;31', 
-    $cwarn    = '00;31', 
-    $cinfo    = '00;00',
-    $cdebug   = '00;34',
-    $cdefault = '07;37'
-  ) {
-    $this->colors= [
-      LogLevel::INFO    => $cinfo,
-      LogLevel::WARN    => $cwarn,
-      LogLevel::ERROR   => $cerror,
-      LogLevel::DEBUG   => $cdebug,
-      LogLevel::NONE    => $cdefault
-    ];
+  public function __construct($target= 'err', $colors= []) {
+    parent::__construct($target);
+    $this->colors= array_merge(self::$DEFAULTS, $colors);
   }
   
   /**
@@ -45,8 +42,10 @@ class ColoredConsoleAppender extends ConsoleAppender {
    */ 
   public function append(LoggingEvent $event) {
     $l= $event->getLevel();
-    fwrite(STDERR, "\x1b[".$this->colors[isset($this->colors[$l]) ? $l : LogLevel::NONE]."m");
-    fwrite(STDERR, $this->layout->format($event));
-    fwrite(STDERR, "\x1b[0m");
+    $this->writer->write(
+      "\x1b[".(isset($this->colors[$l]) ? $this->colors[$l] : '07;37')."m".
+      $this->layout->format($event).
+      "\x1b[0m"
+    );
   }
 }

--- a/src/main/php/util/log/ColoredConsoleAppender.class.php
+++ b/src/main/php/util/log/ColoredConsoleAppender.class.php
@@ -30,7 +30,7 @@ class ColoredConsoleAppender extends ConsoleAppender {
    * @param  [:string] $colors
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($target= 'err', $colors= []) {
+  public function __construct($target= 'out', $colors= []) {
     parent::__construct($target);
     $this->colors= array_merge(self::$DEFAULTS, $colors);
   }

--- a/src/main/php/util/log/ConsoleAppender.class.php
+++ b/src/main/php/util/log/ConsoleAppender.class.php
@@ -1,5 +1,7 @@
 <?php namespace util\log;
 
+use io\streams\StringWriter;
+use lang\IllegalArgumentException;
 use util\cmd\Console;
 
 /**
@@ -17,15 +19,27 @@ class ConsoleAppender extends Appender {
 
   /**
    * Constructor
+   *
+   * @param  string|io.streams.StringWriter $target
+   * @throws lang.IllegalArgumentException
    */
-  public function __construct() {
-    $this->writer= Console::$err;
+  public function __construct($target= 'err') {
+    if ($target instanceof StringWriter) {
+      $this->writer= $target;
+    } else if ('out' === $target) {
+      $this->writer= Console::$out;
+    } else if ('err' === $target) {
+      $this->writer= Console::$err;
+    } else {
+      throw new IllegalArgumentException('Expected either "out", "err" or an io.streams.StringWriter instance');
+    }
   }
   
   /**
    * Append data
    *
-   * @param   util.log.LoggingEvent event
+   * @param  util.log.LoggingEvent event
+   * @return void
    */ 
   public function append(LoggingEvent $event) {
     $this->writer->write($this->layout->format($event));

--- a/src/main/php/util/log/ConsoleAppender.class.php
+++ b/src/main/php/util/log/ConsoleAppender.class.php
@@ -34,6 +34,9 @@ class ConsoleAppender extends Appender {
       throw new IllegalArgumentException('Expected either "out", "err" or an io.streams.StringWriter instance');
     }
   }
+
+  /** @return io.streams.StringWriter */
+  public function writer() { return $this->writer; }
   
   /**
    * Append data

--- a/src/main/php/util/log/ConsoleAppender.class.php
+++ b/src/main/php/util/log/ConsoleAppender.class.php
@@ -23,7 +23,7 @@ class ConsoleAppender extends Appender {
    * @param  string|io.streams.StringWriter $target
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($target= 'err') {
+  public function __construct($target= 'out') {
     if ($target instanceof StringWriter) {
       $this->writer= $target;
     } else if ('out' === $target) {

--- a/src/main/php/util/log/LogSetup.class.php
+++ b/src/main/php/util/log/LogSetup.class.php
@@ -1,8 +1,8 @@
 <?php namespace util\log;
 
-use util\log\layout\DefaultLayout;
 use lang\Value;
 use util\Objects;
+use util\log\layout\DefaultLayout;
 
 /**
  * Logging DSL
@@ -66,10 +66,11 @@ class LogSetup implements Value {
    * Returns a logging category with a console appender attached
    *
    * @param  bool $colors
+   * @param  string $target
    * @return util.log.LogCategory
    */
-  public function toConsole($colors= true) {
-    return self::to($colors ? new ColoredConsoleAppender() : new ConsoleAppender());
+  public function toConsole($colors= true, $target= 'err') {
+    return self::to($colors ? new ColoredConsoleAppender($target) : new ConsoleAppender($target));
   }
 
   /**

--- a/src/main/php/util/log/LogSetup.class.php
+++ b/src/main/php/util/log/LogSetup.class.php
@@ -65,11 +65,11 @@ class LogSetup implements Value {
   /**
    * Returns a logging category with a console appender attached
    *
-   * @param  bool $colors
    * @param  string $target
+   * @param  bool $colors
    * @return util.log.LogCategory
    */
-  public function toConsole($colors= true, $target= 'err') {
+  public function toConsole($target= 'err', $colors= true) {
     return self::to($colors ? new ColoredConsoleAppender($target) : new ConsoleAppender($target));
   }
 

--- a/src/test/php/util/log/unittest/ConsoleAppenderTest.class.php
+++ b/src/test/php/util/log/unittest/ConsoleAppenderTest.class.php
@@ -43,6 +43,11 @@ class ConsoleAppenderTest extends TestCase {
   }
 
   #[@test]
+  public function writes_to_stdout_by_default() {
+    $this->assertEquals(Console::$out, (new ConsoleAppender())->writer());
+  }
+
+  #[@test]
   public function append_to_stderr() {
     $stream= new MemoryOutputStream();
 

--- a/src/test/php/util/log/unittest/ConsoleAppenderTest.class.php
+++ b/src/test/php/util/log/unittest/ConsoleAppenderTest.class.php
@@ -46,14 +46,14 @@ class ConsoleAppenderTest extends TestCase {
   public function append_to_stderr() {
     $stream= new MemoryOutputStream();
 
-    $err= Console::$err->stream();
-    Console::$err->redirect($stream);
+    $err= Console::$err->getStream();
+    Console::$err->setStream($stream);
 
     try {
       $this->category('err')->warn('Test');
       $this->assertEquals('[LOG] Test', $stream->getBytes());
     } finally {
-      Console::$err->redirect($err);
+      Console::$err->setStream($err);
     }
   }
 
@@ -61,14 +61,14 @@ class ConsoleAppenderTest extends TestCase {
   public function append_to_stdout() {
     $stream= new MemoryOutputStream();
 
-    $out= Console::$out->stream();
-    Console::$out->redirect($stream);
+    $out= Console::$out->getStream();
+    Console::$out->setStream($stream);
 
     try {
       $this->category('out')->warn('Test');
       $this->assertEquals('[LOG] Test', $stream->getBytes());
     } finally {
-      Console::$out->redirect($out);
+      Console::$out->setStream($out);
     }
   }
 }

--- a/src/test/php/util/log/unittest/LoggingTest.class.php
+++ b/src/test/php/util/log/unittest/LoggingTest.class.php
@@ -1,15 +1,16 @@
 <?php namespace util\log\unittest;
 
-use util\log\Logging;
-use util\log\LogCategory;
-use util\log\LogLevel;
-use util\log\FileAppender;
-use util\log\ConsoleAppender;
-use util\log\ColoredConsoleAppender;
-use util\log\SyslogAppender;
-use util\log\layout\PatternLayout;
 use io\File;
 use io\Path;
+use util\cmd\Console;
+use util\log\ColoredConsoleAppender;
+use util\log\ConsoleAppender;
+use util\log\FileAppender;
+use util\log\LogCategory;
+use util\log\LogLevel;
+use util\log\Logging;
+use util\log\SyslogAppender;
+use util\log\layout\PatternLayout;
 
 class LoggingTest extends \unittest\TestCase {
 
@@ -25,8 +26,23 @@ class LoggingTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function to_console_out() {
+    $this->assertEquals(Console::$out, Logging::all()->toConsole('out')->getAppenders()[0]->writer());
+  }
+
+  #[@test]
+  public function to_console_err() {
+    $this->assertEquals(Console::$err, Logging::all()->toConsole('err')->getAppenders()[0]->writer());
+  }
+
+  #[@test]
+  public function to_console_with_colors() {
+    $this->assertInstanceOf(ColoredConsoleAppender::class, Logging::all()->toConsole('out', true)->getAppenders()[0]);
+  }
+
+  #[@test]
   public function to_console_without_colors() {
-    $this->assertInstanceOf(ConsoleAppender::class, Logging::all()->toConsole(false)->getAppenders()[0]);
+    $this->assertInstanceOf(ConsoleAppender::class, Logging::all()->toConsole('out', false)->getAppenders()[0]);
   }
 
   #[@test, @values([


### PR DESCRIPTION
This pull request changes `util.log.ConsoleAppender` and `util.log.ColoredConsoleAppender` to log to standard output by default. This is a BC break from how they have worked in the past, but follows the principle of least surprise by aligning them with [log4j's ConsoleAppender]( https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/appender/ConsoleAppender.html) as well as [LogBack's ConsoleAppender](https://logback.qos.ch/apidocs/ch/qos/logback/core/ConsoleAppender.html).

If you need to log to standard error, the target can be passed to the constructor, as well as to the `util.log.LogSetup` utility method `toConsole()`.

```php
$cat= Logging::all()->to(new ConsoleAppender('err'));   // or 'out'
$cat= Logging::all()->toConsole('err');
```

**⚠️ This behavior change is a BC break and will yield a new major version!**

/cc @johannes85 