### PR TITLE
Add util.log.LogConfiguration

### DIFF
--- a/src/main/php/util/log/LogConfiguration.class.php
+++ b/src/main/php/util/log/LogConfiguration.class.php
@@ -1,0 +1,103 @@
+<?php namespace util\log;
+
+use lang\IllegalArgumentException;
+use lang\XPClass;
+use util\PropertyAccess;
+
+/**
+ * Log configuration from a properties object
+ *
+ * ```ini
+ * [default]
+ * uses=console|syslog|files
+ * 
+ * [console]
+ * class=util.log.ConsoleAppender
+ * level=ALL
+ * 
+ * [files]
+ * class=util.log.FileAppender
+ * args="/var/log/server.log"
+ * level=ALL
+ * 
+ * [syslog]
+ * class=util.log.SyslogUdpAppender
+ * args=127.0.0.1|514|server
+ * level=WARN|ERROR
+ * ```
+ *
+ * @test  xp://util.log.unittest.LogConfigurationTest
+ */
+class LogConfiguration {
+  private $categories= [];
+
+  /** Creates a new log configuration from a properties file */
+  public function __construct(PropertyAccess $properties) {
+    foreach ($properties->sections() as $section) {
+      $cat= new LogCategory($section);
+      foreach ($this->appendersFor($properties, $section) as $level => $appender) {
+        $cat->addAppender($appender, $level);
+      }
+      $this->categories[$section]= $cat;
+    }
+  }
+
+  /**
+   * Returns log appenders for a given property file section
+   *
+   * @param  util.PropertyAccess $properties
+   * @param  string $section
+   * @return iterable
+   */
+  private function appendersFor($properties, $section) {
+
+    // Class
+    if ($class= $properties->readString($section, 'class', null)) {
+      $appender= XPClass::forName($class)->newInstance(...$properties->readArray($section, 'args', []));
+      if ($levels= $properties->readArray($section, 'levels', null)) {
+        $level= LogLevel::NONE;
+        foreach ($levels as $name) {
+          $level |= LogLevel::named($name);
+        }
+        yield $level => $appender;
+      } else {
+        yield LogLevel::ALL => $appender;
+      }
+    }
+
+    // Uses, referencing other section
+    if ($uses= $properties->readArray($section, 'uses', null)) {
+      foreach ($uses as $use) {
+        foreach ($this->appendersFor($properties, $use) as $level => $appender) {
+          yield $level => $appender;
+        }
+      }
+    }
+  }
+
+  /** @return [:util.log.LogCategory] */
+  public function categories() { return $this->categories; }
+
+  /**
+   * Test whether this configuration provides a log category by its name
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function provides($name) {
+    return isset($this->categories[$name]);
+  }
+
+  /**
+   * Return a log category by its name
+   *
+   * @param  string $name
+   * @return util.log.LogCategory
+   * @throws lang.IllegalArgumentException
+   */
+  public function category($name) {
+    if (isset($this->categories[$name])) return $this->categories[$name];
+
+    throw new IllegalArgumentException('No log category "'.$name.'"');
+  }
+}

--- a/src/main/php/util/log/LogConfiguration.class.php
+++ b/src/main/php/util/log/LogConfiguration.class.php
@@ -54,7 +54,7 @@ class LogConfiguration {
     // Class
     if ($class= $properties->readString($section, 'class', null)) {
       $appender= XPClass::forName($class)->newInstance(...$properties->readArray($section, 'args', []));
-      if ($levels= $properties->readArray($section, 'levels', null)) {
+      if ($levels= $properties->readArray($section, 'level', null)) {
         $level= LogLevel::NONE;
         foreach ($levels as $name) {
           $level |= LogLevel::named($name);

--- a/src/main/php/util/log/LogConfiguration.class.php
+++ b/src/main/php/util/log/LogConfiguration.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\log;
 
+use lang\FormatException;
 use lang\IllegalArgumentException;
 use lang\XPClass;
 use util\PropertyAccess;
@@ -48,6 +49,7 @@ class LogConfiguration {
    * @param  util.PropertyAccess $properties
    * @param  string $section
    * @return iterable
+   * @throws lang.FormatException
    */
   private function appendersFor($properties, $section) {
 
@@ -68,6 +70,9 @@ class LogConfiguration {
     // Uses, referencing other section
     if ($uses= $properties->readArray($section, 'uses', null)) {
       foreach ($uses as $use) {
+        if (!$properties->hasSection($use)) {
+          throw new FormatException('Uses in section "'.$section.'" references non-existant section "'.$use.'"');
+        }
         foreach ($this->appendersFor($properties, $use) as $level => $appender) {
           yield $level => $appender;
         }

--- a/src/test/php/util/log/unittest/LogConfigurationTest.class.php
+++ b/src/test/php/util/log/unittest/LogConfigurationTest.class.php
@@ -1,0 +1,98 @@
+<?php namespace util\log\unittest;
+
+use io\streams\MemoryInputStream;
+use unittest\TestCase;
+use util\Objects;
+use util\Properties;
+use util\log\ConsoleAppender;
+use util\log\LogConfiguration;
+use util\log\LogLevel;
+
+class LogConfigurationTest extends TestCase {
+
+  /**
+   * Creates a Properties object from a string
+   *
+   * @param  string $properties
+   * @return util.Properties
+   */
+  private function properties($properties) {
+    $p= new Properties(null);
+    $p->load(new MemoryInputStream(trim($properties)));
+    return $p;
+  }
+
+  #[@test]
+  public function can_create() {
+    new LogConfiguration($this->properties(''));
+  }
+
+  #[@test]
+  public function categories_for_empty_file() {
+    $config= new LogConfiguration($this->properties(''));
+    $this->assertEquals([], $config->categories());
+  }
+
+  #[@test]
+  public function categories() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.ConsoleAppender
+    '));
+
+    $this->assertInstanceOf('[:util.log.LogCategory]', $config->categories());
+  }
+
+  #[@test, @values([
+  #  ['default', true],
+  #  ['files', false],
+  #])]
+  public function provides($name, $expected) {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.ConsoleAppender
+    '));
+    $this->assertEquals($expected, $config->provides($name));
+  }
+
+  #[@test]
+  public function category_returns_appender_from_class() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.ConsoleAppender
+    '));
+
+    $appenders= $config->category('default')->getAppenders();
+    $this->assertEquals(1, sizeof($appenders), Objects::stringOf($appenders));
+  }
+
+  #[@test]
+  public function category_returns_appenders_from_uses() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      uses=console|files
+
+      [console]
+      class=util.log.ConsoleAppender
+
+      [files]
+      class=util.log.FileAppender
+      args=test.log
+    '));
+
+    $appenders= $config->category('default')->getAppenders();
+    $this->assertEquals(2, sizeof($appenders), Objects::stringOf($appenders));
+  }
+
+  #[@test]
+  public function category_with_class_and_argument() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.FileAppender
+      args=test.log
+    '));
+
+    $appenders= $config->category('default')->getAppenders();
+    $this->assertEquals('test.log', $appenders[0]->filename);
+  }
+}

--- a/src/test/php/util/log/unittest/LogConfigurationTest.class.php
+++ b/src/test/php/util/log/unittest/LogConfigurationTest.class.php
@@ -5,6 +5,7 @@ use unittest\TestCase;
 use util\Objects;
 use util\Properties;
 use util\log\ConsoleAppender;
+use util\log\FileAppender;
 use util\log\LogConfiguration;
 use util\log\LogLevel;
 
@@ -94,5 +95,26 @@ class LogConfigurationTest extends TestCase {
 
     $appenders= $config->category('default')->getAppenders();
     $this->assertEquals('test.log', $appenders[0]->filename);
+  }
+
+  #[@test]
+  public function categories_with_loglevels() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      uses=console|files
+
+      [console]
+      class=util.log.ConsoleAppender
+      level=INFO
+
+      [files]
+      class=util.log.FileAppender
+      args=test.log
+      level=ERROR
+    '));
+
+    $cat= $config->category('default');
+    $this->assertInstanceOf(ConsoleAppender::class, $cat->getAppenders(LogLevel::INFO)[0]);
+    $this->assertInstanceOf(FileAppender::class, $cat->getAppenders(LogLevel::ERROR)[0]);
   }
 }

--- a/src/test/php/util/log/unittest/LogConfigurationTest.class.php
+++ b/src/test/php/util/log/unittest/LogConfigurationTest.class.php
@@ -124,6 +124,29 @@ class LogConfigurationTest extends TestCase {
   }
 
   #[@test, @expect(
+  #  class= FormatException::class,
+  #  withMessage= 'Class util.log.NonExistantAppender in section "default" cannot be instantiated'
+  #)]
+  public function non_existant_appender() {
+    new LogConfiguration($this->properties('
+      [default]
+      class=util.log.NonExistantAppender
+    '));
+  }
+
+  #[@test, @expect(
+  #  class= FormatException::class,
+  #  withMessage= 'Level TEST in section "default" not recognized'
+  #)]
+  public function non_existant_level() {
+    new LogConfiguration($this->properties('
+      [default]
+      class=util.log.ConsoleAppender
+      level=TEST
+    '));
+  }
+
+  #[@test, @expect(
   #  class= IllegalArgumentException::class,
   #  withMessage= 'No log category "default"'
   #)]

--- a/src/test/php/util/log/unittest/LogConfigurationTest.class.php
+++ b/src/test/php/util/log/unittest/LogConfigurationTest.class.php
@@ -136,6 +136,18 @@ class LogConfigurationTest extends TestCase {
 
   #[@test, @expect(
   #  class= FormatException::class,
+  #  withMessage= 'Class util.log.ConsoleAppender in section "default" cannot be instantiated'
+  #)]
+  public function exceptions_when_instantiating_appenders() {
+    new LogConfiguration($this->properties('
+      [default]
+      class=util.log.ConsoleAppender
+      args=STDIN
+    '));
+  }
+
+  #[@test, @expect(
+  #  class= FormatException::class,
   #  withMessage= 'Level TEST in section "default" not recognized'
   #)]
   public function non_existant_level() {


### PR DESCRIPTION
See https://github.com/xp-framework/logging/issues/11#issuecomment-415737649

## Configuration

```ini
[default]
uses=console|syslog|files

[console]
class=util.log.ConsoleAppender
level=ALL

[files]
class=util.log.FileAppender
args="/var/log/server.log"
level=ALL

[syslog]
class=util.log.SyslogUdpAppender
args=127.0.0.1|514|server
level=WARN|ERROR
```

## API

```php
$c= new LogConfiguration(new Properties('log.ini'));
$cat= $c->category('default');   // Returns console, syslog and files
$cat= $c->category('syslog');    // An appender as configured by "syslog"

$all= $c->categories();  // ["default" => new LogCategory()->withAppenders(...), "syslog" => ...

$name= 'does-not-exist';
$exists= $c->provides($name);    // FALSE
$cat= $c->category($name);       // ***lang.IllegalArgumentException***
```

## Migration

```diff
- $l= Logger::getInstance();
- $l->configure(new Properties('log.ini'));
- $cat= $l->getCategory('default');
+ $c= new LogConfiguration(new Properties('log.ini'));
+ $cat= $c->category('default'); 
```