### PR TITLE
Add support for named arguments via configuration file

### DIFF
--- a/src/main/php/util/log/LogConfiguration.class.php
+++ b/src/main/php/util/log/LogConfiguration.class.php
@@ -59,13 +59,13 @@ class LogConfiguration {
    * @throws lang.FormatException
    */
   private function newAppender($class, $args) {
-    if (empty($args)) {
+    if (null === ($c= $class->getConstructor())) {
       return $class->newInstance();
     } else if (0 === key($args)) {
-      return $class->newInstance(...$args);
+      return $c->newInstance($args);
     } else {
       $pass= [];
-      foreach ($class->getConstructor()->getParameters() as $param) {
+      foreach ($c->getParameters() as $param) {
         $name= $param->getName();
         $pass[]= isset($args[$name]) ? $args[$name] : $param->getDefaultValue();
         unset($args[$name]);
@@ -73,7 +73,7 @@ class LogConfiguration {
       if ($args) {
         throw new FormatException('Unknown named argument(s) '.implode(', ', array_keys($args)));
       }
-      return $class->newInstance(...$pass);
+      return $c->newInstance($pass);
     }
   }
 

--- a/src/main/php/util/log/LogConfiguration.class.php
+++ b/src/main/php/util/log/LogConfiguration.class.php
@@ -50,6 +50,34 @@ class LogConfiguration {
   }
 
   /**
+   * Creates a new log appender from a class and arguments, which are either
+   * a list matching the constructor argument order or a map of named arguments.
+   *
+   * @param  lang.XPClass $class
+   * @param  var[]|[:var] $args
+   * @return util.log.LogAppender
+   * @throws lang.FormatException
+   */
+  private function newAppender($class, $args) {
+    if (empty($args)) {
+      return $class->newInstance();
+    } else if (0 === key($args)) {
+      return $class->newInstance(...$args);
+    } else {
+      $pass= [];
+      foreach ($class->getConstructor()->getParameters() as $param) {
+        $name= $param->getName();
+        $pass[]= isset($args[$name]) ? $args[$name] : $param->getDefaultValue();
+        unset($args[$name]);
+      }
+      if ($args) {
+        throw new FormatException('Unknown named argument(s) '.implode(', ', array_keys($args)));
+      }
+      return $class->newInstance(...$pass);
+    }
+  }
+
+  /**
    * Returns log appenders for a given property file section
    *
    * @param  util.PropertyAccess $properties
@@ -70,7 +98,7 @@ class LogConfiguration {
     // Class
     if ($class= $properties->readString($section, 'class', null)) {
       try {
-        $appender= XPClass::forName($class)->newInstance(...$properties->readArray($section, 'args', []));
+        $appender= $this->newAppender(XPClass::forName($class), $properties->readArray($section, 'args', []));
       } catch (Throwable $e) {
         throw new FormatException('Class '.$class.' in section "'.$section.'" cannot be instantiated', $e);
       }

--- a/src/test/php/util/log/unittest/LogConfigurationTest.class.php
+++ b/src/test/php/util/log/unittest/LogConfigurationTest.class.php
@@ -192,6 +192,42 @@ class LogConfigurationTest extends TestCase {
   }
 
   #[@test]
+  public function category_with_class_and_named_argument() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.FileAppender
+      args[file]=test.log
+    '));
+
+    $appenders= $config->category('default')->getAppenders();
+    $this->assertEquals('test.log', $appenders[0]->filename);
+  }
+
+  #[@test]
+  public function category_with_class_and_named_arguments() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.SyslogUdpAppender
+      args[ip]=127.0.0.1
+      args[identifier]=test
+    '));
+
+    $appenders= $config->category('default')->getAppenders();
+    $this->assertEquals('127.0.0.1:514', $appenders[0]->ip.':'.$appenders[0]->port);
+  }
+
+  #[@test, @expect(FormatException::class)]
+  public function category_with_non_existant_named_argument() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.SyslogUdpAppender
+      args[non-existant-parameter]=***
+    '));
+
+    $config->category('default')->getAppenders();
+  }
+
+  #[@test]
   public function categories_with_loglevels() {
     $config= new LogConfiguration($this->properties('
       [default]

--- a/src/test/php/util/log/unittest/LogConfigurationTest.class.php
+++ b/src/test/php/util/log/unittest/LogConfigurationTest.class.php
@@ -1,15 +1,18 @@
 <?php namespace util\log\unittest;
 
 use io\streams\MemoryInputStream;
+use lang\ClassLoader;
 use lang\FormatException;
 use lang\IllegalArgumentException;
 use unittest\TestCase;
 use util\Objects;
 use util\Properties;
+use util\log\Appender;
 use util\log\ConsoleAppender;
 use util\log\FileAppender;
 use util\log\LogConfiguration;
 use util\log\LogLevel;
+use util\log\LoggingEvent;
 
 class LogConfigurationTest extends TestCase {
 
@@ -189,6 +192,20 @@ class LogConfigurationTest extends TestCase {
 
     $appenders= $config->category('default')->getAppenders();
     $this->assertEquals('test.log', $appenders[0]->filename);
+  }
+
+  #[@test, @expect(FormatException::class)]
+  public function category_with_class_and_missing_argument() {
+    ClassLoader::defineClass('util.log.unittest.LogConfigurationTest_Appender', Appender::class, [], [
+      '__construct' => function($arg) { /* ... */ },
+      'append' => function(LoggingEvent $event) { /* ... */ },
+    ]);
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.unittest.LogConfigurationTest_Appender
+    '));
+
+    $config->category('default')->getAppenders();
   }
 
   #[@test]


### PR DESCRIPTION
For example, set ip and identifier, but skip the port argument, using its default value

```ini
[default]
class=util.log.SyslogUdpAppender
args[ip]=127.0.0.1
args[identifier]=test
```

/cc @johannes85 