### PR TITLE
Make layout configurable via "layout" in log configuration

### DIFF
--- a/src/main/php/util/log/LogConfiguration.class.php
+++ b/src/main/php/util/log/LogConfiguration.class.php
@@ -99,6 +99,10 @@ class LogConfiguration {
     if ($class= $properties->readString($section, 'class', null)) {
       try {
         $appender= $this->newAppender(XPClass::forName($class), $properties->readArray($section, 'args', []));
+        if ($layout= $properties->readArray($section, 'layout', null)) {
+          $class= array_shift($layout);
+          $appender->setLayout(XPClass::forName($class)->newInstance(...$layout));
+        }
       } catch (Throwable $e) {
         throw new FormatException('Class '.$class.' in section "'.$section.'" cannot be instantiated', $e);
       }

--- a/src/main/php/util/log/LogConfiguration.class.php
+++ b/src/main/php/util/log/LogConfiguration.class.php
@@ -99,8 +99,14 @@ class LogConfiguration {
     if ($class= $properties->readString($section, 'class', null)) {
       try {
         $appender= $this->newAppender(XPClass::forName($class), $properties->readArray($section, 'args', []));
-        if ($layout= $properties->readArray($section, 'layout', null)) {
-          $appender->setLayout(XPClass::forName(array_shift($layout))->newInstance(...$layout));
+        if ($layout= $properties->readString($section, 'layout', null)) {
+          if (false !== ($p= strcspn($layout, '('))) {
+            $appender->setLayout(XPClass::forName(substr($layout, 0, $p))->newInstance(...eval(
+              'return ['.substr($layout, $p + 1, -1).'];'
+            )));
+          } else {
+            $appender->setLayout(XPClass::forName($layout)->newInstance());
+          }
         }
       } catch (Throwable $e) {
         throw new FormatException('Class '.$class.' in section "'.$section.'" cannot be instantiated', $e);

--- a/src/main/php/util/log/LogConfiguration.class.php
+++ b/src/main/php/util/log/LogConfiguration.class.php
@@ -100,8 +100,7 @@ class LogConfiguration {
       try {
         $appender= $this->newAppender(XPClass::forName($class), $properties->readArray($section, 'args', []));
         if ($layout= $properties->readArray($section, 'layout', null)) {
-          $class= array_shift($layout);
-          $appender->setLayout(XPClass::forName($class)->newInstance(...$layout));
+          $appender->setLayout(XPClass::forName(array_shift($layout))->newInstance(...$layout));
         }
       } catch (Throwable $e) {
         throw new FormatException('Class '.$class.' in section "'.$section.'" cannot be instantiated', $e);

--- a/src/test/php/util/log/unittest/LogConfigurationTest.class.php
+++ b/src/test/php/util/log/unittest/LogConfigurationTest.class.php
@@ -271,7 +271,7 @@ class LogConfigurationTest extends TestCase {
     $config= new LogConfiguration($this->properties('
       [default]
       class=util.log.SyslogUdpAppender
-      layout=util.log.layout.PatternLayout|%c - %m
+      layout=util.log.layout.PatternLayout("%c - %m")
     '));
 
     $appenders= $config->category('default')->getAppenders();

--- a/src/test/php/util/log/unittest/LogConfigurationTest.class.php
+++ b/src/test/php/util/log/unittest/LogConfigurationTest.class.php
@@ -13,6 +13,7 @@ use util\log\FileAppender;
 use util\log\LogConfiguration;
 use util\log\LogLevel;
 use util\log\LoggingEvent;
+use util\log\layout\PatternLayout;
 
 class LogConfigurationTest extends TestCase {
 
@@ -263,5 +264,17 @@ class LogConfigurationTest extends TestCase {
     $cat= $config->category('default');
     $this->assertInstanceOf(ConsoleAppender::class, $cat->getAppenders(LogLevel::INFO)[0]);
     $this->assertInstanceOf(FileAppender::class, $cat->getAppenders(LogLevel::ERROR)[0]);
+  }
+
+  #[@test]
+  public function category_with_class_and_layout() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.SyslogUdpAppender
+      layout=util.log.layout.PatternLayout|%c - %m
+    '));
+
+    $appenders= $config->category('default')->getAppenders();
+    $this->assertEquals(new PatternLayout('%c - %m'), $appenders[0]->getLayout());
   }
 }

--- a/src/test/php/util/log/unittest/LogConfigurationTest.class.php
+++ b/src/test/php/util/log/unittest/LogConfigurationTest.class.php
@@ -277,4 +277,15 @@ class LogConfigurationTest extends TestCase {
     $appenders= $config->category('default')->getAppenders();
     $this->assertEquals(new PatternLayout('%c - %m'), $appenders[0]->getLayout());
   }
+
+  #[@test, @expect(FormatException::class)]
+  public function category_with_class_and_non_existant_layout() {
+    $config= new LogConfiguration($this->properties('
+      [default]
+      class=util.log.SyslogUdpAppender
+      layout=util.log.layout.NonExistantLayout
+    '));
+
+    $config->category('default')->getAppenders();
+  }
 }


### PR DESCRIPTION
Example:

```ini
[default]
class=util.log.SyslogUdpAppender
layout=util.log.layout.PatternLayout|%c - %m
```

/cc @johannes85 