### PR TITLE
Fix nesting of deeply structured arrays and objects

### DIFF
--- a/src/main/php/util/log/Layout.class.php
+++ b/src/main/php/util/log/Layout.class.php
@@ -1,11 +1,11 @@
 <?php namespace util\log;
 
-use lang\{Generic, Value};
+use lang\Value;
 
 /**
  * Takes care of formatting log entries
  *
- * @test  xp://util.log.unittest.LayoutTest
+ * @test  util.log.unittest.LayoutTest
  */
 abstract class Layout {
 
@@ -24,12 +24,11 @@ abstract class Layout {
       return 'true';
     } else if (is_string($arg)) {
       return '' === $indent ? $arg : '"'.$arg.'"';
-    } else if ($arg instanceof Value || $arg instanceof Generic) {
+    } else if ($arg instanceof Value) {
       return $arg->toString();
     } else if ([] === $arg) {
       return '[]';
     } else if (is_array($arg)) {
-      $indent.= '  ';
       if (0 === key($arg)) {
         $r= '';
         foreach ($arg as $value) {
@@ -37,21 +36,22 @@ abstract class Layout {
         }
         return '['.substr($r, 2).']';
       } else {
+        $n= $indent.'  ';
         $r= '[';
         foreach ($arg as $key => $value) {
-          $r.= "\n".$indent.$key.' => '.$this->stringOf($value, $indent);
+          $r.= "\n{$n}{$key} => ".$this->stringOf($value, $n);
         }
-        return $r."\n]";
+        return $r."\n{$indent}]";
       }
     } else if ($arg instanceof \Closure) {
       return $arg();
     } else if (is_object($arg)) {
-      $indent.= '  ';
+      $n= $indent.'  ';
       $r= nameof($arg).'@{';
       foreach ((array)$arg as $key => $value) {
-        $r.= "\n".$indent.$key.' => '.$this->stringOf($value, $indent);
+        $r.= "\n{$n}{$key} => ".$this->stringOf($value, $n);
       }
-      return $r."\n}";
+      return $r."\n{$indent}}";
     } else {
       return (string)$arg;
     }


### PR DESCRIPTION
Currently, this is an example of the output:

```
[11:14:09 20212 debug] >>> [
  jsonrpc => "2.0"
  id => 8
  method => "tools/call"
  params => [
    _meta => [
      progressToken => 42
]
    name => "greeting_send"
    arguments => [
      address => "thekid@internet"
]
]
]
```

The closing braces are completely unaligned!

* * * 

This is the way it looks with this patch:

```
[11:14:09 20212 debug] >>> [
  jsonrpc => "2.0"
  id => 5
  method => "tools/call"
  params => [
    _meta => [
      progressToken => 42
    ]
    name => "greeting_send"
    arguments => [
      address => "thekid@internet"
    ]
  ]
]